### PR TITLE
Fix ordering of library paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,30 +61,30 @@ endif
 
 ifeq ($(SYSTEM),Linux)
     AR          = /usr/bin/ar
-    LIBDIRS     = $(GCCLOCALLIBDIRS)                                          \
-                  /lib64                                                      \
-                  $(LLVMDIR)/lib64                                            \
+    LIBDIRS     = $(LLVMDIR)/lib64                                            \
                   $(PREFIX)/lib64                                             \
+	          $(GCCLOCALLIBDIRS)                                          \
+                  /lib64                                                      \
                   $(GCCOTHERLIBDIRS)                                          \
                   /opt/swt/lib64
     LDFLAGS    += -Wl,--enable-new-dtags
     LDFLAGS    += -Wl,-rpath,'$$ORIGIN/../../lib64'
     LDFLAGS    += $(foreach L,$(LIBDIRS),                                     \
-                    -Wl,-L,$(abspath $(L)),-rpath,$(abspath $(L)))
+                    -L$(abspath $(L)) -Wl,-rpath,$(abspath $(L)))
     ifneq (,$(wildcard $(foreach L,$(LIBDIRS),$(L)/libtinfo.so)))
         EXTRALIBS += -ltinfo
     endif
 else ifeq ($(SYSTEM),SunOS)
     AR          = /usr/ccs/bin/ar
     CXXFLAGS   += -DBYTE_ORDER=BIG_ENDIAN
-    LIBDIRS     = $(GCCLOCALLIBDIRS)                                          \
-                  $(LLVMDIR)/lib64                                            \
+    LIBDIRS     = $(LLVMDIR)/lib64                                            \
                   $(PREFIX)/lib64                                             \
+                  $(GCCLOCALLIBDIRS)                                          \
                   $(GCCOTHERLIBDIRS)                                          \
                   /opt/swt/lib64
     LDFLAGS    += -Wl,-rpath,$$ORIGIN/../../lib64
     LDFLAGS    += $(foreach L,$(LIBDIRS),                                     \
-                    -Wl,-L,$(abspath $(L)),-rpath,$(abspath $(L)))
+                    -L$(abspath $(L)) -Wl,-rpath,$(abspath $(L)))
     EXTRALIBS  += -lrt
     ifneq (,$(wildcard $(foreach L,$(LIBDIRS),$(L)/libtinfo.so)))
         EXTRALIBS += -ltinfo

--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,7 @@ Build-Depends: build-base,
                llvm-4.0,
                aspell,
                libncurses5-dev,
-               libtinfo5,
+               libtinfo-dev,
                libz-dev,
                rhel-dts-debhelper [amd64],
                which
@@ -19,7 +19,7 @@ Standards-Version: 3.8.4
 Package: bde-verify
 Architecture: amd64 solaris10-sparc
 Description: bde_verify
-Depends: coreutils, gcc, perl, aspell, aspell-en
+Depends: coreutils, gcc, perl, aspell, aspell-en, libncurses5, libtinfo5, libz1
 
 Package: libbde-verify-dev
 Depends: llvm-4.0


### PR DESCRIPTION
The current `Makefile` uses a different order for link-time library search paths and runtime library search paths. This means you may end up with a runtime dependency on a different version of a library than the one found at runtime, causing warnings or failures at runtime. This pull fixes the ordering so it is the same in both.

Also, add dependencies on all required runtime libraries in the debian metadata.