### PR TITLE
    CMake option to honor install prefix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -378,6 +378,7 @@ if (NOT HONOR_INSTALL_PREFIX)
   )
 endif()
 message("install prefix = ${CMAKE_INSTALL_PREFIX}")
+message("If this seems wrong, turn HONOR_INSTALL_PREFIX ON or OFF")
 
 install(TARGETS
     csabase

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,8 @@ set(BDE_VERIFY_VERSION_MINOR "3")
 set(BDE_VERIFY_VERSION_PATCH "15")
 set(BDE_VERIFY_VERSION "${BDE_VERIFY_VERSION_MAJOR}.${BDE_VERIFY_VERSION_MINOR}.${BDE_VERIFY_VERSION_PATCH}")
 
+option(HONOR_INSTALL_PREFIX "Install on the CMAKE_INSTALL_PREFIX, without changing it" OFF)
+
 add_subdirectory(bde-verify-vs)
 
 find_package(LLVM REQUIRED)
@@ -361,19 +363,21 @@ llvmlib(rt)
 llvmlib(tinfo)
 llvmlib(malloc)
 
+if (NOT HONOR_INSTALL_PREFIX)
+  string(REGEX REPLACE
+      "^.*[/\\]([^/\\]*)$"
+      "${CMAKE_CURRENT_SOURCE_DIR}/${CMAKE_SYSTEM_NAME}-\\1"
+      CMAKE_INSTALL_PREFIX
+      "/${CMAKE_CXX_COMPILER}"
+  )
+  string(REGEX REPLACE
+      "[.].*$"
+      ""
+      CMAKE_INSTALL_PREFIX
+      ${CMAKE_INSTALL_PREFIX}
+  )
+endif()
 message("install prefix = ${CMAKE_INSTALL_PREFIX}")
-string(REGEX REPLACE
-    "^.*[/\\]([^/\\]*)$"
-    "${CMAKE_CURRENT_SOURCE_DIR}/${CMAKE_SYSTEM_NAME}-\\1"
-    CMAKE_INSTALL_PREFIX
-    "/${CMAKE_CXX_COMPILER}"
-)
-string(REGEX REPLACE
-    "[.].*$"
-    ""
-    CMAKE_INSTALL_PREFIX
-    ${CMAKE_INSTALL_PREFIX}
-)
 
 install(TARGETS
     csabase


### PR DESCRIPTION
    It's unusual for CMake projects to change the user defined
    install prefix, but I understand that this has usages inside of
    bloomberg - unfortunately this breaks for everyone else that
    wants to conform to bde standards.

    This patch adds a new option for cmake, that's turned off by default
    so bloomberg still get's the right behavior, but for us outside
    of the company, we can pass -DHONOR_INSTALL_PREFIX=ON during
    configuration stage, or later using ccmake, and have the common
    cmake behavior of installing the software on user specified prefix
